### PR TITLE
Load map metadata from YAML file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@vueuse/core": "^10.10.0",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.1",
+        "js-yaml": "4.1.0",
         "radix-vue": "^1.8.3",
         "tailwind-merge": "^2.3.0",
         "tailwindcss-animate": "^1.0.7",
@@ -1198,6 +1199,11 @@
       "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
       "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg=="
     },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+    },
     "node_modules/aria-hidden": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.4.tgz",
@@ -2014,6 +2020,17 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/js-sdsl"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/leven": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
     "@vueuse/core": "^10.10.0",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
+    "@types/js-yaml": "^4.1.0",
+    "js-yaml": "^4.1.0",
     "radix-vue": "^1.8.3",
     "tailwind-merge": "^2.3.0",
     "tailwindcss-animate": "^1.0.7",
@@ -25,8 +27,7 @@
     "vee-validate": "^4.13.1",
     "vue": "^3.4.21",
     "vue-json-pretty": "^2.4.0",
-    "zod": "^3.23.8",
-    "js-yaml": "4.1.0"
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@types/node": "^20.14.2",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "vee-validate": "^4.13.1",
     "vue": "^3.4.21",
     "vue-json-pretty": "^2.4.0",
-    "zod": "^3.23.8"
+    "zod": "^3.23.8",
+    "js-yaml": "4.1.0"
   },
   "devDependencies": {
     "@types/node": "^20.14.2",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@vueuse/core": "^10.10.0",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
-    "@types/js-yaml": "^4.1.0",
+    "@types/js-yaml": "^4.0.9",
     "js-yaml": "^4.1.0",
     "radix-vue": "^1.8.3",
     "tailwind-merge": "^2.3.0",

--- a/src/components/LayoutDialog.vue
+++ b/src/components/LayoutDialog.vue
@@ -256,7 +256,7 @@ function load_map_metadata(metadata_file: File) {
             auto-focus
           />
         </div>
-        <div class="grid gap-2" v-if="layout.backgroundImage.natural_width">
+        <div class="grid gap-2" v-if="layout.backgroundImage">
           <HoverCard :open-delay="2000">
             <HoverCardTrigger>
               <Label for="mapMetadata">Map metadata</Label>

--- a/src/components/LayoutDialog.vue
+++ b/src/components/LayoutDialog.vue
@@ -220,6 +220,24 @@ function handleImageUpload(event: Event) {
             auto-focus
           />
         </div>
+        <div class="grid gap-2" v-if="layout.backgroundImage">
+          <HoverCard :open-delay="2000">
+            <HoverCardTrigger>
+              <Label for="mapMetadata">Map metadata</Label>
+            </HoverCardTrigger>
+            <HoverCardContent>
+              Select a YAML file to load map metadata. The file should contain
+              'origin' and 'resolution' fields.
+            </HoverCardContent>
+          </HoverCard>
+          <Input
+            id="mapMetadata"
+            type="file"
+            accept=".yaml,.yml"
+            @change="handleMetadataUpload"
+            auto-focus
+          />
+        </div>
         <div class="grid grid-cols-2 gap-4" v-if="layout.backgroundImage">
           <div class="grid gap-2">
             <HoverCard :open-delay="2000">

--- a/src/components/LayoutDialog.vue
+++ b/src/components/LayoutDialog.vue
@@ -83,7 +83,7 @@ function handleImageUpload(event: Event) {
     const file = input.files[0];
     const reader = new FileReader();
 
-    reader.onload = e => {
+    reader.onload = (e) => {
       if (e.target?.result) {
         // get real width and height
         const map_image = new Image();
@@ -92,10 +92,10 @@ function handleImageUpload(event: Event) {
           const imageHeight = map_image.naturalHeight;
           
           // populate layout
-        layout.backgroundImage = {
+          layout.backgroundImage = {
             image: map_image.src,
-          x: layout.backgroundImage?.x || 0,
-          y: layout.backgroundImage?.y || 0,
+            x: layout.backgroundImage?.x || 0,
+            y: layout.backgroundImage?.y || 0,
             width: layout.backgroundImage?.width || imageWidth,
             height: layout.backgroundImage?.height || imageHeight,
             natural_width: imageWidth,
@@ -107,10 +107,42 @@ function handleImageUpload(event: Event) {
         map_image.src = e.target.result as string;
       }
     };
-
     reader.readAsDataURL(file);
   }
 }
+
+function handleMetadataUpload(event: Event) {
+  const input = event.target as HTMLInputElement;
+  if (input.files && input.files[0]) {
+    const metadata_file = input.files[0];
+    if (metadata_file) {
+      console.log("yaml file: ", metadata_file);
+      const reader = new FileReader();
+      reader.onload = () => {
+        try {
+          const yamlText = reader.result as string;
+          const parsedData = load(yamlText);
+          console.log("map metadata: ", parsedData);
+          // Extract resolution and origin from the parsed data
+          if (parsedData?.resolution && parsedData?.origin) {
+            layout.backgroundImage.x = parsedData.origin[0]
+            layout.backgroundImage.y = parsedData.origin[1]
+            layout.backgroundImage.width = parsedData.resolution * layout.backgroundImage.natural_width;
+            layout.backgroundImage.height = parsedData.resolution * layout.backgroundImage.natural_height;    
+          } else {
+            console.error("Failed to extract resolution and origin from map metadata.");
+          }    
+
+        } catch (error) {
+          console.error("Error parsing YAML map metadata file:", error);
+        }
+        console.log("layout.backgroundImage: ", layout.backgroundImage);
+      };
+      reader.readAsText(metadata_file);
+    };
+  };
+}
+
 </script>
 
 <template>
@@ -254,8 +286,7 @@ function handleImageUpload(event: Event) {
               v-model="layout.backgroundImage.x"
               auto-focus
             />
-          </div>
-
+          </div>          
           <div class="grid gap-2">
             <HoverCard :open-delay="2000">
               <HoverCardTrigger>

--- a/src/components/LayoutDialog.vue
+++ b/src/components/LayoutDialog.vue
@@ -21,6 +21,7 @@ import {
 import {LayoutController} from '@/controllers/layout.controller';
 import {SideBarController} from '@/controllers/sideBar.controller';
 import {Layout} from '@/types/layout';
+import {MapMetadata} from '@/types/visualizationLayout';
 import {load} from 'js-yaml';
 
 const props = defineProps({
@@ -126,7 +127,7 @@ function handleMetadataUpload(event: Event) {
 }
 
 function loadMapMetadata(metadata_file: File) {
-  if (!layout.backgroundImage.image) {
+  if (!layout.backgroundImage?.image) {
     return
   }
   if (metadata_file) {
@@ -135,12 +136,14 @@ function loadMapMetadata(metadata_file: File) {
       try {
         const yamlText = reader.result as string;
         const parsedData = load(yamlText);
+        const mapMetadata: MapMetadata = parsedData as MapMetadata;
+
         // Extract resolution and origin from the parsed data
-        if (parsedData?.resolution && parsedData?.origin) {
-          layout.backgroundImage.x = parsedData.origin[0]
-          layout.backgroundImage.y = parsedData.origin[1]
-          layout.backgroundImage.width = parsedData.resolution * layout.backgroundImage.natural_width;
-          layout.backgroundImage.height = parsedData.resolution * layout.backgroundImage.natural_height;
+        if (layout?.backgroundImage && mapMetadata?.resolution && mapMetadata?.origin) {
+          layout.backgroundImage.x = mapMetadata.origin[0]
+          layout.backgroundImage.y = mapMetadata.origin[1]
+          layout.backgroundImage.width = mapMetadata.resolution * layout.backgroundImage.natural_width;
+          layout.backgroundImage.height = mapMetadata.resolution * layout.backgroundImage.natural_height;
         } else {
           console.error("Failed to extract resolution and origin from map metadata.");
         }
@@ -155,15 +158,15 @@ function loadMapMetadata(metadata_file: File) {
 }
 
 function updateInputsFromLayout() {
-  if (!layout.backgroundImage) {
+  if (!layout?.backgroundImage) {
     console.log("updateInputsFromLayout(): Layout has no backgroundImage field");
     return;
   }
   // update inputs
-  const x_input = document.querySelector("#backgroundX");
-  const y_input = document.querySelector("#backgroundY");
-  const width_input = document.querySelector("#backgroundWidth");
-  const height_input = document.querySelector("#backgroundHeight");
+  const x_input = document.querySelector("#backgroundX") as typeof Input | null;
+  const y_input = document.querySelector("#backgroundY") as typeof Input | null;
+  const width_input = document.querySelector("#backgroundWidth") as typeof Input | null;
+  const height_input = document.querySelector("#backgroundHeight") as typeof Input | null;
   
   if (!x_input || !y_input || !width_input || !height_input) {
     console.log("updateInputsFromLayout(): Not all input not found");

--- a/src/components/LayoutDialog.vue
+++ b/src/components/LayoutDialog.vue
@@ -60,8 +60,8 @@ function createEmptyLayout() {
     stations: [],
     backgroundImage: {
       image: '',
-      natural_width: 0,
-      natural_height: 0,
+      naturalWidth: 0,
+      naturalHeight: 0,
       x: 0,
       y: 0,
       width: 10,
@@ -99,8 +99,8 @@ function handleImageUpload(event: Event) {
             y: layout.backgroundImage?.y || 0,
             width: layout.backgroundImage?.width || imageWidth,
             height: layout.backgroundImage?.height || imageHeight,
-            natural_width: imageWidth,
-            natural_height: imageHeight,
+            naturalWidth: imageWidth,
+            naturalHeight: imageHeight,
           };
           // update metadata from input if one was loaded before the map
           const metadata_input = document.querySelector('#mapMetadata');
@@ -144,12 +144,14 @@ function loadMapMetadata(metadata_file: File) {
           mapMetadata?.resolution &&
           mapMetadata?.origin
         ) {
-          layout.backgroundImage.x = mapMetadata.origin[0];
-          layout.backgroundImage.y = mapMetadata.origin[1];
-          layout.backgroundImage.width =
-            mapMetadata.resolution * layout.backgroundImage.natural_width;
-          layout.backgroundImage.height =
-            mapMetadata.resolution * layout.backgroundImage.natural_height;
+          props.layout.backgroundImage.value.x = mapMetadata.origin[0];
+          props.layout.backgroundImage.value.y = mapMetadata.origin[1];
+          props.layout.backgroundImage.value.width =
+            mapMetadata.resolution *
+            props.layout.backgroundImage.value.naturalWidth;
+          props.layout.backgroundImage.value.height =
+            mapMetadata.resolution *
+            props.layout.backgroundImage.value.naturalHeight;
         } else {
           console.error(
             'Failed to extract resolution and origin from map metadata.',
@@ -185,17 +187,10 @@ function updateInputsFromLayout() {
     console.log('updateInputsFromLayout(): Not all input not found');
     return;
   }
-  x_input.value = layout.backgroundImage.x;
-  x_input.dispatchEvent(new Event('input'));
-
-  y_input.value = layout.backgroundImage.y;
-  y_input.dispatchEvent(new Event('input'));
-
-  width_input.value = layout.backgroundImage.width;
-  width_input.dispatchEvent(new Event('input'));
-
-  height_input.value = layout.backgroundImage.height;
-  height_input.dispatchEvent(new Event('input'));
+  x_input.value = props.layout.backgroundImage.value.x;
+  y_input.value = props.layout.backgroundImage.value.y;
+  width_input.value = props.layout.backgroundImage.value.width;
+  height_input.value = props.layout.backgroundImage.value.height;
 }
 </script>
 

--- a/src/components/LayoutDialog.vue
+++ b/src/components/LayoutDialog.vue
@@ -21,6 +21,7 @@ import {
 import {LayoutController} from '@/controllers/layout.controller';
 import {SideBarController} from '@/controllers/sideBar.controller';
 import {Layout} from '@/types/layout';
+import {load} from 'js-yaml';
 
 const props = defineProps({
   tools: {

--- a/src/components/LayoutDialog.vue
+++ b/src/components/LayoutDialog.vue
@@ -143,9 +143,38 @@ function load_map_metadata(metadata_file: File) {
       } catch (error) {
         console.error("Error parsing YAML map metadata file:", error);
       }
+      update_inputs_from_layout();
     };
     reader.readAsText(metadata_file);
   };
+}
+
+function update_inputs_from_layout() {
+  if (!layout.backgroundImage) {
+    console.log("update_inputs_from_layout(): Layout has no backgroundImage field");
+    return;
+  }
+  // update inputs
+  const x_input = document.querySelector("#backgroundX");
+  const y_input = document.querySelector("#backgroundY");
+  const width_input = document.querySelector("#backgroundWidth");
+  const height_input = document.querySelector("#backgroundHeight");
+  
+  if (!x_input || !y_input || !width_input || !height_input) {
+    console.log("update_inputs_from_layout(): Not all input not found");
+    return;
+  }
+  x_input.value = layout.backgroundImage.x;
+  x_input.dispatchEvent(new Event('input'));
+
+  y_input.value = layout.backgroundImage.y;
+  y_input.dispatchEvent(new Event('input'));
+
+  width_input.value = layout.backgroundImage.width;
+  width_input.dispatchEvent(new Event('input'));
+
+  height_input.value = layout.backgroundImage.height;
+  height_input.dispatchEvent(new Event('input'));
 }
 </script>
 

--- a/src/components/LayoutDialog.vue
+++ b/src/components/LayoutDialog.vue
@@ -139,7 +139,7 @@ function load_map_metadata(metadata_file: File) {
         } else {
           console.error("Failed to extract resolution and origin from map metadata.");
         }
-
+        
       } catch (error) {
         console.error("Error parsing YAML map metadata file:", error);
       }
@@ -256,7 +256,7 @@ function load_map_metadata(metadata_file: File) {
             auto-focus
           />
         </div>
-        <div class="grid gap-2" v-if="layout.backgroundImage">
+        <div class="grid gap-2" v-if="layout.backgroundImage.natural_width">
           <HoverCard :open-delay="2000">
             <HoverCardTrigger>
               <Label for="mapMetadata">Map metadata</Label>

--- a/src/components/LayoutDialog.vue
+++ b/src/components/LayoutDialog.vue
@@ -59,14 +59,14 @@ function createEmptyLayout() {
     edges: [],
     stations: [],
     backgroundImage: {
-      image: "",
+      image: '',
       natural_width: 0,
       natural_height: 0,
       x: 0,
       y: 0,
       width: 10,
       height: 10,
-    }
+    },
   };
 }
 function saveLayout() {
@@ -85,7 +85,7 @@ function handleImageUpload(event: Event) {
     const file = input.files[0];
     const reader = new FileReader();
 
-    reader.onload = (e) => {
+    reader.onload = e => {
       if (e.target?.result) {
         const map_image = new Image();
         map_image.onload = async () => {
@@ -100,13 +100,13 @@ function handleImageUpload(event: Event) {
             width: layout.backgroundImage?.width || imageWidth,
             height: layout.backgroundImage?.height || imageHeight,
             natural_width: imageWidth,
-            natural_height: imageHeight
-          };          
-          // update metadata from input if one was loaded before the map
-          const metadata_input = document.querySelector("#mapMetadata");
-          if (metadata_input) {
-            metadata_input.dispatchEvent(new Event('change'));     
+            natural_height: imageHeight,
           };
+          // update metadata from input if one was loaded before the map
+          const metadata_input = document.querySelector('#mapMetadata');
+          if (metadata_input) {
+            metadata_input.dispatchEvent(new Event('change'));
+          }
         };
         map_image.src = e.target.result as string;
 
@@ -123,12 +123,12 @@ function handleMetadataUpload(event: Event) {
   if (input.files && input.files[0]) {
     const metadata_file = input.files[0];
     loadMapMetadata(metadata_file);
-  };
+  }
 }
 
 function loadMapMetadata(metadata_file: File) {
   if (!layout.backgroundImage?.image) {
-    return
+    return;
   }
   if (metadata_file) {
     const reader = new FileReader();
@@ -139,37 +139,50 @@ function loadMapMetadata(metadata_file: File) {
         const mapMetadata: MapMetadata = parsedData as MapMetadata;
 
         // Extract resolution and origin from the parsed data
-        if (layout?.backgroundImage && mapMetadata?.resolution && mapMetadata?.origin) {
-          layout.backgroundImage.x = mapMetadata.origin[0]
-          layout.backgroundImage.y = mapMetadata.origin[1]
-          layout.backgroundImage.width = mapMetadata.resolution * layout.backgroundImage.natural_width;
-          layout.backgroundImage.height = mapMetadata.resolution * layout.backgroundImage.natural_height;
+        if (
+          layout?.backgroundImage &&
+          mapMetadata?.resolution &&
+          mapMetadata?.origin
+        ) {
+          layout.backgroundImage.x = mapMetadata.origin[0];
+          layout.backgroundImage.y = mapMetadata.origin[1];
+          layout.backgroundImage.width =
+            mapMetadata.resolution * layout.backgroundImage.natural_width;
+          layout.backgroundImage.height =
+            mapMetadata.resolution * layout.backgroundImage.natural_height;
         } else {
-          console.error("Failed to extract resolution and origin from map metadata.");
+          console.error(
+            'Failed to extract resolution and origin from map metadata.',
+          );
         }
-        
       } catch (error) {
-        console.error("Error parsing YAML map metadata file:", error);
+        console.error('Error parsing YAML map metadata file:', error);
       }
       updateInputsFromLayout();
     };
     reader.readAsText(metadata_file);
-  };
+  }
 }
 
 function updateInputsFromLayout() {
   if (!layout?.backgroundImage) {
-    console.log("updateInputsFromLayout(): Layout has no backgroundImage field");
+    console.log(
+      'updateInputsFromLayout(): Layout has no backgroundImage field',
+    );
     return;
   }
   // update inputs
-  const x_input = document.querySelector("#backgroundX") as typeof Input | null;
-  const y_input = document.querySelector("#backgroundY") as typeof Input | null;
-  const width_input = document.querySelector("#backgroundWidth") as typeof Input | null;
-  const height_input = document.querySelector("#backgroundHeight") as typeof Input | null;
-  
+  const x_input = document.querySelector('#backgroundX') as typeof Input | null;
+  const y_input = document.querySelector('#backgroundY') as typeof Input | null;
+  const width_input = document.querySelector('#backgroundWidth') as
+    | typeof Input
+    | null;
+  const height_input = document.querySelector('#backgroundHeight') as
+    | typeof Input
+    | null;
+
   if (!x_input || !y_input || !width_input || !height_input) {
-    console.log("updateInputsFromLayout(): Not all input not found");
+    console.log('updateInputsFromLayout(): Not all input not found');
     return;
   }
   x_input.value = layout.backgroundImage.x;
@@ -300,8 +313,8 @@ function updateInputsFromLayout() {
             </HoverCardTrigger>
             <HoverCardContent>
               Select a YAML file to load map metadata. The file should contain
-              'origin' and 'resolution' fields. You must load a map first or
-              the loaded metadata will be ignored.
+              'origin' and 'resolution' fields. You must load a map first or the
+              loaded metadata will be ignored.
             </HoverCardContent>
           </HoverCard>
           <Input

--- a/src/components/LayoutDialog.vue
+++ b/src/components/LayoutDialog.vue
@@ -110,7 +110,7 @@ function handleImageUpload(event: Event) {
         map_image.src = e.target.result as string;
 
         // TODO: if there is a metadata file in the same folder, it should be loaded it here
-        // load_map_metadata(metadata_file);
+        // loadMapMetadata(metadata_file);
       }
     };
     reader.readAsDataURL(file);
@@ -121,11 +121,11 @@ function handleMetadataUpload(event: Event) {
   const input = event.target as HTMLInputElement;
   if (input.files && input.files[0]) {
     const metadata_file = input.files[0];
-    load_map_metadata(metadata_file);
+    loadMapMetadata(metadata_file);
   };
 }
 
-function load_map_metadata(metadata_file: File) {
+function loadMapMetadata(metadata_file: File) {
   if (!layout.backgroundImage.image) {
     return
   }
@@ -148,15 +148,15 @@ function load_map_metadata(metadata_file: File) {
       } catch (error) {
         console.error("Error parsing YAML map metadata file:", error);
       }
-      update_inputs_from_layout();
+      updateInputsFromLayout();
     };
     reader.readAsText(metadata_file);
   };
 }
 
-function update_inputs_from_layout() {
+function updateInputsFromLayout() {
   if (!layout.backgroundImage) {
-    console.log("update_inputs_from_layout(): Layout has no backgroundImage field");
+    console.log("updateInputsFromLayout(): Layout has no backgroundImage field");
     return;
   }
   // update inputs
@@ -166,7 +166,7 @@ function update_inputs_from_layout() {
   const height_input = document.querySelector("#backgroundHeight");
   
   if (!x_input || !y_input || !width_input || !height_input) {
-    console.log("update_inputs_from_layout(): Not all input not found");
+    console.log("updateInputsFromLayout(): Not all input not found");
     return;
   }
   x_input.value = layout.backgroundImage.x;

--- a/src/components/LayoutDialog.vue
+++ b/src/components/LayoutDialog.vue
@@ -99,6 +99,11 @@ function handleImageUpload(event: Event) {
             height: layout.backgroundImage?.height || imageHeight,
             natural_width: imageWidth,
             natural_height: imageHeight
+          };          
+          // update metadata from input if one was loaded before the map
+          const metadata_input = document.querySelector("#mapMetadata");
+          if (metadata_input) {
+            metadata_input.dispatchEvent(new Event('change'));     
           };
         };
         map_image.src = e.target.result as string;
@@ -121,7 +126,6 @@ function handleMetadataUpload(event: Event) {
 
 function load_map_metadata(metadata_file: File) {
   if (!layout.backgroundImage.image) {
-    console.error("Cannot load map metadata, background image is not set.");
     return
   }
   if (metadata_file) {
@@ -292,7 +296,8 @@ function update_inputs_from_layout() {
             </HoverCardTrigger>
             <HoverCardContent>
               Select a YAML file to load map metadata. The file should contain
-              'origin' and 'resolution' fields.
+              'origin' and 'resolution' fields. You must load a map first or
+              the loaded metadata will be ignored.
             </HoverCardContent>
           </HoverCard>
           <Input

--- a/src/components/LayoutDialog.vue
+++ b/src/components/LayoutDialog.vue
@@ -57,12 +57,14 @@ function createEmptyLayout() {
     edges: [],
     stations: [],
     backgroundImage: {
-      image: '',
+      image: "",
+      natural_width: 0,
+      natural_height: 0,
       x: 0,
       y: 0,
       width: 10,
       height: 10,
-    },
+    }
   };
 }
 function saveLayout() {
@@ -83,13 +85,26 @@ function handleImageUpload(event: Event) {
 
     reader.onload = e => {
       if (e.target?.result) {
+        // get real width and height
+        const map_image = new Image();
+        map_image.onload = async () => {
+          const imageWidth = map_image.naturalWidth;
+          const imageHeight = map_image.naturalHeight;
+          
+          // populate layout
         layout.backgroundImage = {
-          image: e.target.result as string,
+            image: map_image.src,
           x: layout.backgroundImage?.x || 0,
           y: layout.backgroundImage?.y || 0,
-          width: layout.backgroundImage?.width || 10,
-          height: layout.backgroundImage?.height || 10,
-        };
+            width: layout.backgroundImage?.width || imageWidth,
+            height: layout.backgroundImage?.height || imageHeight,
+            natural_width: imageWidth,
+            natural_height: imageHeight
+          };      
+          console.log("map natural width (px): ", layout.backgroundImage.natural_width);
+          console.log("map natural height (px): ", layout.backgroundImage.natural_height);   
+        };   
+        map_image.src = e.target.result as string;
       }
     };
 

--- a/src/controllers/layout.controller.ts
+++ b/src/controllers/layout.controller.ts
@@ -35,7 +35,7 @@ export class LayoutController {
     width: 10,
     height: 10,
     natural_width: 10,
-    natural_height: 10
+    natural_height: 10,
   });
   private oldLayoutId = '';
   private graph: any;
@@ -57,7 +57,7 @@ export class LayoutController {
         width: 10,
         height: 10,
         natural_width: 10,
-        natural_height: 10
+        natural_height: 10,
       },
     };
     this.vdaLayouts.push(layout);
@@ -130,7 +130,7 @@ export class LayoutController {
       width: 10,
       height: 10,
       natural_width: 10,
-      natural_height: 10
+      natural_height: 10,
     };
 
     // Check if layout exists

--- a/src/controllers/layout.controller.ts
+++ b/src/controllers/layout.controller.ts
@@ -34,6 +34,8 @@ export class LayoutController {
     y: 0,
     width: 10,
     height: 10,
+    natural_width: 10,
+    natural_height: 10
   });
   private oldLayoutId = '';
   private graph: any;
@@ -54,6 +56,8 @@ export class LayoutController {
         y: 0,
         width: 10,
         height: 10,
+        natural_width: 10,
+        natural_height: 10
       },
     };
     this.vdaLayouts.push(layout);
@@ -125,6 +129,8 @@ export class LayoutController {
       y: 0,
       width: 10,
       height: 10,
+      natural_width: 10,
+      natural_height: 10
     };
 
     // Check if layout exists

--- a/src/controllers/layout.controller.ts
+++ b/src/controllers/layout.controller.ts
@@ -34,8 +34,8 @@ export class LayoutController {
     y: 0,
     width: 10,
     height: 10,
-    natural_width: 10,
-    natural_height: 10,
+    naturalWidth: 10,
+    naturalHeight: 10,
   });
   private oldLayoutId = '';
   private graph: any;
@@ -56,8 +56,8 @@ export class LayoutController {
         y: 0,
         width: 10,
         height: 10,
-        natural_width: 10,
-        natural_height: 10,
+        naturalWidth: 10,
+        naturalHeight: 10,
       },
     };
     this.vdaLayouts.push(layout);
@@ -129,8 +129,8 @@ export class LayoutController {
       y: 0,
       width: 10,
       height: 10,
-      natural_width: 10,
-      natural_height: 10,
+      naturalWidth: 10,
+      naturalHeight: 10,
     };
 
     // Check if layout exists

--- a/src/types/visualizationLayout.ts
+++ b/src/types/visualizationLayout.ts
@@ -7,6 +7,11 @@ export interface VisualizationLayout {
   backgroundImage?: BackgroundImage;
 }
 
+export interface MapMetadata {
+  resolution: number;
+  origin: [number, number];
+}
+
 export interface BackgroundImage {
   image: string;
   x: number;

--- a/src/types/visualizationLayout.ts
+++ b/src/types/visualizationLayout.ts
@@ -18,7 +18,7 @@ export interface BackgroundImage {
   y: number;
   width: number;
   height: number;
-  natural_width: number;
-  natural_height: number;
+  naturalWidth: number;
+  naturalHeight: number;
 }
 export type VisualizationLayouts = Record<string, VisualizationLayout>;

--- a/src/types/visualizationLayout.ts
+++ b/src/types/visualizationLayout.ts
@@ -13,5 +13,7 @@ export interface BackgroundImage {
   y: number;
   width: number;
   height: number;
+  natural_width: number;
+  natural_height: number;
 }
 export type VisualizationLayouts = Record<string, VisualizationLayout>;


### PR DESCRIPTION
Hi,

A nice feature for the layout loader would consist in directly loading the map metadata (i.e., origin and size of background image) from a YAML file.
Otherwise, it requires manual math operation to retrieve the width/height from the size of the image in pixels and the map resolution (i.e., meter/px)

A commonly used format in the ROS2 community (see [here](https://wiki.ros.org/map_server#YAML_format] for instance) is the following:

```yaml
# map.yaml confg file

image: map.png  # absolute or relative path to the image
resolution: 0.04  # meter / px
origin: [0.0 , 0.0, 0.0]  # map origin and orientation

# other default fields, not useful for a LIF editor
negate: 0
occupied_thresh: 0.2
free_thresh: 0.2
``` 

I implemented this in the `LayoutDialog` using [js-yaml](https://www.npmjs.com/package/js-yaml).
Is that something you would be interested in adding to the editor?

Note that this particular implementation might not be optimal, I have never used JavaScript before...
Also, it might require some auto-linting, I didn't find a pre-commit-config in the project.

Cheers!